### PR TITLE
Update pyload_installer.sh

### DIFF
--- a/pyload/pyload_installer.sh
+++ b/pyload/pyload_installer.sh
@@ -53,7 +53,7 @@ Type=simple
 User=pyload
 Group=pyload
 ExecStart=/usr/local/bin/pyload --userdir /var/lib/pyload
-Restart=on-failure
+Restart=always
 RestartSec=5s
 TimeoutSec=20
 


### PR DESCRIPTION
Pyload doesn't restart from the UI because the service process exits cleanly, which doesn't trigger the `restart=on-failure'.